### PR TITLE
fix: config storage-layout to output in json

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -19,7 +19,7 @@ const exactify = (variable: StorageVariable): StorageVariableExact => ({
 });
 
 export const createLayout = (contract: string, cwd = ".") => {
-  return execSync(`forge inspect ${contract} storage-layout`, {
+  return execSync(`forge inspect ${contract} storage-layout --json`, {
     encoding: "utf-8",
     cwd,
   });


### PR DESCRIPTION
After latest updates, forge requires a `--json` flag to output storage layout in json format. Without this flag, `forge inspect ${contract} storage-layout` returns a formated txt that looks like this which can not be parsed as JSON:
```
╭---------------------+--------------------------------------------------+------+--------+-------+----------------------------------╮
| Name                | Type                                             | Slot | Offset | Bytes | Contract                         |
+===================================================================================================================================+
| initialized         | bool                                             | 0    | 0      | 1     | contracts/swap/Broker.sol:Broker |
|---------------------+--------------------------------------------------+------+--------+-------+----------------------------------|
| _owner              | address                                          | 0    | 1      | 20    | contracts/swap/Broker.sol:Broker |
|---------------------+--------------------------------------------------+------+--------+-------+----------------------------------|
| _status             | uint256                                          | 1    | 0      | 32    | contracts/swap/Broker.sol:Broker |
╰---------------------+--------------------------------------------------+------+--------+-------+----------------------------------╯
```

 This was causing [foundry-storage-check](https://github.com/Rubilmax/foundry-storage-check/tree/main) to error out with
 `SyntaxError: Unexpected token '╭', " ╭---------"... is not valid JSON` when run on any contract.
 https://github.com/mento-protocol/mento-core/actions/runs/12198857654/job/34031496550
 
 
 
  This PR aims to fix this issue by forcing forge inspect to return a json output using the `--json` flag